### PR TITLE
Updating twitter_ads sdk to use API version 8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-twitter-ads',
           'backoff==1.8.0',
           'requests==2.23.0',
           'singer-python==5.9.0',
-          'twitter-ads==7.0.0'
+          'twitter-ads==8.0.0'
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change
Upgrading Twitter Ads SDK to use API version v8. A few things to note: 

- During testing I noticed that a specific endpoint,`/line_item_apps`, was failing with a `ROUTE_NOT_FOUND` 404 code in _both_ v7 and v8. As this error seemed to be present in the current version of the API I ignored it in order to test all other endpoints for v8.
- Additionally, after running for a while, I was getting the same `requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))` error in both v7 and v8 of my testing environment. Not sure if this is isolated to my particular environment but as far as the API itself, it appears that v8 does not introduce any breaking changes based on the success of the streams it is able to get through before reaching that connection issue and in that sense I believe it is safe to upgrade to v8.

Here are the streams the tap was able to successfully go through before reaching the disconnect exception:
```
The output is valid.
It contained 119981 messages for 38 streams.

     38 schema messages
 119848 record messages
     95 state messages

Details by stream:
+--------------------------------+---------+---------+
| stream                         | records | schemas |
+--------------------------------+---------+---------+
| accounts                       | 0       | 1       |
| account_media                  | 0       | 1       |
| advertiser_business_categories | 16      | 1       |
| bidding_rules                  | 64      | 1       |
| campaigns                      | 0       | 1       |
| cards_website                  | 0       | 1       |
| cards_video_website            | 0       | 1       |
| cards_image_app_download       | 0       | 1       |
| cards_video_app_download       | 0       | 1       |
| cards_poll                     | 0       | 1       |
| cards_image_conversation       | 0       | 1       |
| cards_video_conversation       | 0       | 1       |
| cards_image_direct_message     | 0       | 1       |
| cards_video_direct_message     | 0       | 1       |
| content_categories             | 392     | 1       |
| funding_instruments            | 0       | 1       |
| iab_categories                 | 15      | 1       |
| line_items                     | 0       | 1       |
| targeting_criteria             | 0       | 1       |
| media_creatives                | 0       | 1       |
| preroll_call_to_actions        | 0       | 1       |
| promoted_accounts              | 0       | 1       |
| promoted_tweets                | 0       | 1       |
| promotable_users               | 0       | 1       |
| scheduled_promoted_tweets      | 0       | 1       |
| tailored_audiences             | 0       | 1       |
| targeting_app_store_categories | 84      | 1       |
| targeting_conversations        | 43223   | 1       |
| targeting_devices              | 649     | 1       |
| targeting_events               | 649     | 1       |
| targeting_interests            | 361     | 1       |
| targeting_languages            | 21      | 1       |
| targeting_locations            | 74118   | 1       |
| targeting_network_operators    | 160     | 1       |
| targeting_platform_versions    | 53      | 1       |
| targeting_platforms            | 4       | 1       |
| targeting_tv_markets           | 39      | 1       |
| targeting_tv_shows             | 0       | 1       |
+--------------------------------+---------+---------+
```

# Manual QA steps
 - Run the tap and validate that there are no exceptions related to the `twitter_ads` SDK using API version 8.
 
# Risks
 - Because I was not able to fully complete the tap run before receiving the `ConnectionError` exception, it's possible there could be some other related to API version 8 that I did not reach.
 
# Rollback steps
 - revert this branch
