### PR TITLE
Bump twitter-ads SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-twitter-ads',
           'backoff==1.8.0',
           'requests==2.23.0',
           'singer-python==5.9.0',
-          'twitter-ads==8.0.0'
+          'twitter-ads==9.0.1'
       ],
       extras_require={
           'dev': [

--- a/tap_twitter_ads/streams.py
+++ b/tap_twitter_ads/streams.py
@@ -264,19 +264,20 @@ STREAMS = {
         }
     },
     # Reference: https://developer.twitter.com/en/docs/ads/campaign-management/api-reference/line-item-apps#line-item-apps
-    'line_item_apps': {
-        'path': 'accounts/{account_id}/line_item_apps',
-        'data_key': 'data',
-        'key_properties': ['id'],
-        'replication_method': 'INCREMENTAL',
-        'replication_keys': ['updated_at'],
-        'params': {
-            'sort_by': ['updated_at-desc'],
-            'with_deleted': '{with_deleted}',
-            'count': 1000,
-            'cursor': None
-        }
-    },
+    #   Endpoint and docs return a 404 - remove stream for now
+    # 'line_item_apps': {
+    #     'path': 'accounts/{account_id}/line_item_apps',
+    #     'data_key': 'data',
+    #     'key_properties': ['id'],
+    #     'replication_method': 'INCREMENTAL',
+    #     'replication_keys': ['updated_at'],
+    #     'params': {
+    #         'sort_by': ['updated_at-desc'],
+    #         'with_deleted': '{with_deleted}',
+    #         'count': 1000,
+    #         'cursor': None
+    #     }
+    # },
     # Reference: https://developer.twitter.com/en/docs/ads/campaign-management/api-reference/media-creatives#media-creatives
     'media_creatives': {
         'path': 'accounts/{account_id}/media_creatives',
@@ -363,7 +364,7 @@ STREAMS = {
     },
     # Reference: https://developer.twitter.com/en/docs/ads/audiences/api-reference/tailored-audiences#tailored-audiences
     'tailored_audiences': {
-        'path': 'accounts/{account_id}/tailored_audiences',
+        'path': 'accounts/{account_id}/custom_audiences',
         'data_key': 'data',
         'key_properties': ['id'],
         'replication_method': 'INCREMENTAL',


### PR DESCRIPTION
# Description of change
- addressing issues per [TDL-15206](https://jira.talendforge.org/browse/TDL-15206)
- bumping `twitter-ads` to latest version (9.0.1)
- removing `line_item_apps` stream as endpoint and docs are missing on latest version of the Twitter Ads API (v10)
- changing path for the `tailored_audiences` to reflect API changes

# Manual QA steps
 - ran tap locally
 - checked against `singer-check-tap` and `target-stitch --dry-run`
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
