### PR TITLE
Tdl 18652 write individual bookmark for each account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,17 @@ jobs:
             source /usr/local/share/virtualenvs/tap-twitter-ads/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-twitter-ads/bin/activate
+            pip install coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_twitter_ads --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:
@@ -27,16 +27,10 @@ jobs:
       - run:
           name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-twitter-ads \
-                       --target=target-stitch \
-                       --orchestrator=stitch-orchestrator \
-                       --email=harrison+sandboxtest@stitchdata.com \
-                       --password=$SANDBOX_PASSWORD \
-                       --client-id=50 \
-                       tests
+            run-test --tap=tap-twitter-ads tests
 workflows:
   version: 2
   commit:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-twitter-ads',
           'backoff==1.8.0',
           'requests==2.23.0',
           'singer-python==5.9.0',
-          'twitter-ads==9.0.1'
+          'twitter-ads==10.0.0'
       ],
       extras_require={
           'dev': [

--- a/tap_twitter_ads/streams.py
+++ b/tap_twitter_ads/streams.py
@@ -87,21 +87,24 @@ class TwitterAds:
             raise err
         
     # get bookmark for the stream
-    def get_bookmark(self, state, stream, default):
+    def get_bookmark(self, state, stream, default, account_id):
         # default only populated on initial sync
         if (state is None) or ('bookmarks' not in state):
             return default
         return (
             state
             .get('bookmarks', {})
-            .get(stream, default)
+            .get(stream, {})
+            .get(account_id, default) # Return account wise bookmark value
         )
         
     # to read bookmarks in sync mode     
-    def write_bookmark(self, state, stream, value):
+    def write_bookmark(self, state, stream, value, account_id):
         if 'bookmarks' not in state:
             state['bookmarks'] = {}
-        state['bookmarks'][stream] = value
+
+        state['bookmarks'][stream] = state['bookmarks'].get(stream, {}) # Retrieve existing bookmark value
+        state['bookmarks'][stream][account_id] = value # Update bookmark value for particular account
         LOGGER.info('Stream: {} - Write state, bookmark value: {}'.format(stream, value))
         singer.write_state(state)   
             
@@ -233,7 +236,7 @@ class TwitterAds:
         LOGGER.info('sub_types = {}'.format(sub_types)) # COMMENT OUT
 
         # Bookmark datetimes
-        last_datetime = self.get_bookmark(state, stream_name, start_date)
+        last_datetime = self.get_bookmark(state, stream_name, start_date, account_id)
         if not last_datetime or last_datetime is None:
             last_datetime = start_date
         last_dttm = strptime_to_utc(last_datetime)
@@ -445,7 +448,7 @@ class TwitterAds:
 
         # Update the state with the max_bookmark_value for the stream
         if bookmark_field:
-            self.write_bookmark(state, stream_name, max_bookmark_value)
+            self.write_bookmark(state, stream_name, max_bookmark_value, account_id)
 
         return total_records
         # End sync_endpoint
@@ -503,7 +506,7 @@ class Reports(TwitterAds):
         LOGGER.info('Account ID: {} - timezone: {}'.format(account_id, tzone))
 
         # Bookmark datetimes
-        last_datetime = self.get_bookmark(state, report_name, start_date)
+        last_datetime = self.get_bookmark(state, report_name, start_date, account_id)
         last_dttm = strptime_to_utc(last_datetime).astimezone(timezone)
         max_bookmark_value = last_datetime
 
@@ -723,7 +726,7 @@ class Reports(TwitterAds):
                 # End: for async_results_url in async_results_urls
 
             # Update the state with the max_bookmark_value for the date window
-            self.write_bookmark(state, report_name, max_bookmark_value)
+            self.write_bookmark(state, report_name, max_bookmark_value, account_id)
 
             # Increment date window
             window_start = window_end

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,369 @@
+import unittest
+import os
+import tap_tester.connections as connections
+import tap_tester.menagerie as menagerie
+import tap_tester.runner as runner
+from datetime import datetime as dt
+from datetime import timedelta
+import dateutil.parser
+import pytz
+
+
+class TwitterAds(unittest.TestCase):
+    start_date = ""
+    START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+    BOOKMARK_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+    PRIMARY_KEYS = "table-key-properties"
+    REPLICATION_METHOD = "forced-replication-method"
+    REPLICATION_KEYS = "valid-replication-keys"
+    FULL_TABLE = "FULL_TABLE"
+    INCREMENTAL = "INCREMENTAL"
+    OBEYS_START_DATE = "obey-start-date"
+    PAGE_SIZE = 1000
+    account_id = ""
+
+    def tap_name(self):
+        return "tap-twitter-ads"
+
+    def get_type(self):
+        return "platform.twitter-ads"
+
+    def get_credentials(self):
+        return {
+            'consumer_key': os.getenv('TAP_TWITTER_ADS_CONSUMER_KEY'),
+            'consumer_secret': os.getenv('TAP_TWITTER_ADS_CONSUMER_SECRET'),
+            'access_token': os.getenv('TAP_TWITTER_ADS_ACCESS_TOKEN'),
+            'access_token_secret': os.getenv('TAP_TWITTER_ADS_ACCESS_TOKEN_SECRET')
+        }
+
+    def get_properties(self, original: bool = True):
+        """Configuration properties required for the tap."""
+
+        return_value = {
+            "account_ids": os.getenv("TAP_TWITTER_ADS_ACCOUNT_IDS"),
+            "attribution_window": os.getenv("TAP_TWITTER_ADS_ATTRIBUTION_WINDOW"),
+            "with_deleted": os.getenv("TAP_TWITTER_ADS_WITH_DELETED"),
+            "country_codes": os.getenv("TAP_TWITTER_ADS_COUNTRY_CODES"),
+            "start_date": "2019-03-01T00:00:00Z",
+            "page_size": self.PAGE_SIZE,
+            "reports": [
+                {
+                    "name": "accounts_daily_report",
+                    "entity": "ACCOUNT",
+                    "segment": "NO_SEGMENT",
+                    "granularity": "HOUR"
+                },
+                {
+                    "name": "campaigns_daily_report",
+                    "entity": "CAMPAIGN",
+                    "segment": "NO_SEGMENT",
+                    "granularity": "HOUR"
+                }
+            ]
+        }
+        self.account_id = os.getenv("TAP_TWITTER_ADS_ACCOUNT_IDS").split(" ")[0]
+        if original:
+            return return_value
+
+        # Reassign start date
+        return_value["start_date"] = self.start_date
+        return return_value
+
+    def setUp(self):
+        required_env = {
+            "TAP_TWITTER_ADS_CONSUMER_KEY",
+            "TAP_TWITTER_ADS_CONSUMER_SECRET",
+            "TAP_TWITTER_ADS_ACCESS_TOKEN",
+            "TAP_TWITTER_ADS_ACCESS_TOKEN_SECRET",
+            "TAP_TWITTER_ADS_ACCOUNT_IDS",
+            "TAP_TWITTER_ADS_ATTRIBUTION_WINDOW",
+            "TAP_TWITTER_ADS_WITH_DELETED",
+            "TAP_TWITTER_ADS_COUNTRY_CODES"
+        }
+        missing_envs = [v for v in required_env if not os.getenv(v)]
+        if missing_envs:
+            raise Exception("set " + ", ".join(missing_envs))
+
+    def expected_metadata(self):
+        """The expected streams and metadata about the streams"""
+        default_metadata = {
+            self.REPLICATION_KEYS: {"updated_at"},
+            self.PRIMARY_KEYS: {"id"},
+            self.REPLICATION_METHOD: self.INCREMENTAL,
+            self.OBEYS_START_DATE: True
+        }
+
+        targeting_endpoint_metadata = {
+            self.PRIMARY_KEYS: {"targeting_value"},
+            self.REPLICATION_METHOD: self.FULL_TABLE,
+            self.OBEYS_START_DATE: False
+        }
+        report_metadata = {
+            self.REPLICATION_KEYS: {"end_time"},
+            self.PRIMARY_KEYS: {"__sdc_dimensions_hash_key"},
+            self.REPLICATION_METHOD: self.INCREMENTAL,
+            self.OBEYS_START_DATE: True
+        }
+        return {
+            'accounts': default_metadata,
+            'account_media': default_metadata,
+            'bidding_rules': {
+                self.PRIMARY_KEYS: {"currency"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False
+            },
+            "advertiser_business_categories": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False
+            },
+            "campaigns": default_metadata,
+            "cards_website": default_metadata,
+            "cards_video_website": default_metadata,
+            "cards_image_app_download": default_metadata,
+            "cards_video_app_download": default_metadata,
+            "cards_poll": default_metadata,
+            "cards_image_conversation": default_metadata,
+            "cards_video_conversation": default_metadata,
+            "cards_image_direct_message": default_metadata,
+            "cards_video_direct_message": default_metadata,
+            "content_categories": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False
+            },
+            "funding_instruments": default_metadata,
+            "iab_categories": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False
+            },
+            "line_items": default_metadata,
+            "targeting_criteria": {
+                self.PRIMARY_KEYS: {"line_item_id", "id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: True
+            },
+            "media_creatives": default_metadata,
+            "preroll_call_to_actions": default_metadata,
+            "promoted_accounts": default_metadata,
+            "promoted_tweets": default_metadata,
+            "promotable_users": default_metadata,
+            "scheduled_promoted_tweets": default_metadata,
+            "tailored_audiences": default_metadata,
+            "targeting_app_store_categories": targeting_endpoint_metadata,
+            "targeting_conversations": targeting_endpoint_metadata,
+            "targeting_devices": targeting_endpoint_metadata,
+            "targeting_events": {
+                self.PRIMARY_KEYS: {"targeting_value"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: True
+            },
+            "targeting_interests": targeting_endpoint_metadata,
+            "targeting_languages": targeting_endpoint_metadata,
+            "targeting_locations": targeting_endpoint_metadata,
+            "targeting_network_operators": targeting_endpoint_metadata,
+            "targeting_platform_versions": targeting_endpoint_metadata,
+            "targeting_platforms": targeting_endpoint_metadata,
+            "targeting_tv_markets":  {
+                self.PRIMARY_KEYS: {"locale"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False
+            },
+            "targeting_tv_shows": targeting_endpoint_metadata,
+            "tweets": {
+                self.REPLICATION_KEYS: {"created_at"},
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.OBEYS_START_DATE: True
+            },
+            "accounts_daily_report": report_metadata,
+            "campaigns_daily_report": report_metadata,
+        }
+
+    def expected_streams(self):
+        """A set of expected stream names"""
+        return set(self.expected_metadata().keys())
+
+    def expected_primary_keys(self):
+        """
+        return a dictionary with key of table name and value as a set of primary key fields"""
+        return {table: properties.get(self.PRIMARY_KEYS) or set()
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_replication_keys(self):
+        """
+        return a dictionary with key of table name and value as a set of replication key fields"""
+        return {table: properties.get(self.REPLICATION_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_automatic_fields(self):
+        """return a dictionary with key of table name and value as a set of automatic key fields"""
+
+        return {table: ((self.expected_primary_keys().get(table) or set()) |
+                        (self.expected_replication_keys().get(table) or set()))
+                for table in self.expected_metadata()}
+
+    def expected_replication_method(self):
+        """return a dictionary with key of table name nd value of replication method"""
+        return {table: properties.get(self.REPLICATION_METHOD, None)
+                for table, properties
+                in self.expected_metadata().items()}
+
+#########################
+#   Helper Methods      #
+#########################
+
+    def run_and_verify_check_mode(self, conn_id):
+        """
+        Run the tap in check mode and verify it succeeds.
+        This should be ran prior to field selection and initial sync.
+        Return the connection id and found catalogs from menagerie.
+        """
+        # run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['stream_name'], found_catalogs))
+        self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
+        print("discovered schemas are OK")
+
+        return found_catalogs
+
+    def run_and_verify_sync(self, conn_id):
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        sync_record_count = runner.examine_target_output_file(self,
+                                                              conn_id,
+                                                              self.expected_streams(),
+                                                              self.expected_primary_keys())
+
+        self.assertGreater(
+            sum(sync_record_count.values()), 0,
+            msg="failed to replicate any data: {}".format(sync_record_count)
+        )
+        print("total replicated row count: {}".format(sum(sync_record_count.values())))
+
+        return sync_record_count
+
+    def perform_and_verify_table_and_field_selection(self,
+                                                     conn_id,
+                                                     test_catalogs,
+                                                     select_all_fields=True):
+        """
+        Perform table and field selection based off of the streams to select
+        set and field selection parameters.
+        Verify this results in the expected streams selected and all or no
+        fields selected for those streams.
+        """
+
+        # Select all available fields or select no fields from all testable streams
+        self.select_all_streams_and_fields(
+            conn_id=conn_id, catalogs=test_catalogs, select_all_fields=select_all_fields
+        )
+
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Ensure our selection affects the catalog
+        expected_selected = [tc.get('stream_name') for tc in test_catalogs]
+        for cat in catalogs:
+            catalog_entry = menagerie.get_annotated_schema(conn_id, cat['stream_id'])
+
+            # Verify all testable streams are selected
+            selected = catalog_entry.get('annotated-schema').get('selected')
+            print("Validating selection on {}: {}".format(cat['stream_name'], selected))
+            if cat['stream_name'] not in expected_selected:
+                self.assertFalse(selected, msg="Stream selected, but not testable.")
+                continue # Skip remaining assertions if we aren't selecting this stream
+            self.assertTrue(selected, msg="Stream not selected.")
+
+            if select_all_fields:
+                # Verify all fields within each selected stream are selected
+                for field, field_props in catalog_entry.get('annotated-schema').get('properties').items():
+                    field_selected = field_props.get('selected')
+                    print("\tValidating selection on {}.{}: {}".format(
+                        cat['stream_name'], field, field_selected))
+                    self.assertTrue(field_selected, msg="Field not selected.")
+            else:
+                # Verify only automatic fields are selected
+                expected_automatic_fields = self.expected_automatic_fields().get(cat['stream_name'])
+                selected_fields = self.get_selected_fields_from_metadata(catalog_entry['metadata'])
+                self.assertEqual(expected_automatic_fields, selected_fields)
+
+    @staticmethod
+    def get_selected_fields_from_metadata(metadata):
+        selected_fields = set()
+        for field in metadata:
+            is_field_metadata = len(field['breadcrumb']) > 1
+            inclusion_automatic_or_selected = (
+                field['metadata']['selected'] is True or \
+                field['metadata']['inclusion'] == 'automatic'
+            )
+            if is_field_metadata and inclusion_automatic_or_selected:
+                selected_fields.add(field['breadcrumb'][1])
+        return selected_fields
+
+
+    @staticmethod
+    def select_all_streams_and_fields(conn_id, catalogs, select_all_fields: bool = True):
+        """Select all streams and all fields within streams"""
+        for catalog in catalogs:
+            schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+
+            non_selected_properties = []
+            if not select_all_fields:
+                # get a list of all properties so that none are selected
+                non_selected_properties = schema.get('annotated-schema', {}).get(
+                    'properties', {}).keys()
+
+            connections.select_catalog_and_fields_via_metadata(
+                conn_id, catalog, schema, [], non_selected_properties)
+
+    def calculated_states_by_stream(self, current_state):
+        timedelta_by_stream = {stream: [0,0,1]  # {stream_name: [days, hours, minutes], ...}
+                               for stream in self.expected_streams()}
+
+        stream_to_calculated_state = {stream: {self.account_id: ""} for stream in current_state['bookmarks'].keys()}
+        for stream, state in current_state['bookmarks'].items():
+            state_as_datetime = dateutil.parser.parse(state[self.account_id])
+
+            days, hours, minutes = timedelta_by_stream[stream]
+            calculated_state_as_datetime = state_as_datetime - timedelta(days=days, hours=hours, minutes=minutes)
+
+            calculated_state_formatted = dt.strftime(calculated_state_as_datetime, self.BOOKMARK_FORMAT)
+
+            stream_to_calculated_state[stream]["18ce558llv7"] = calculated_state_formatted
+
+        return stream_to_calculated_state
+
+    def convert_state_to_utc(self, date_str):
+        """
+        Convert a saved bookmark value of the form '2020-08-25T13:17:36-07:00' to
+        a string formatted utc datetime,
+        in order to compare aginast json formatted datetime values
+        """
+        date_object = dateutil.parser.parse(date_str)
+        date_object_utc = date_object.astimezone(tz=pytz.UTC)
+        return dt.strftime(date_object_utc, "%Y-%m-%dT%H:%M:%SZ")
+
+    def timedelta_formatted(self, dtime, days=0):
+        try:
+            date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
+            return_date = date_stripped + timedelta(days=days)
+
+            return dt.strftime(return_date, self.START_DATE_FORMAT)
+
+        except ValueError:
+                return Exception("Datetime object is not of the format: {}".format(self.START_DATE_FORMAT))

--- a/tests/test_twitter_ads_bookmark.py
+++ b/tests/test_twitter_ads_bookmark.py
@@ -1,0 +1,203 @@
+import tap_tester.connections as connections
+import tap_tester.runner as runner
+import tap_tester.menagerie as menagerie
+
+from base import TwitterAds
+
+class BookmarkTest(TwitterAds):
+    """Test tap sets a bookmark and respects it for the next sync of a stream"""
+    
+    def name(self):
+        return "tap_tester_twitter_ads_bookmark_test"
+
+    def test_run(self):
+        """
+        Verify that for each stream you can do a sync which records bookmarks.
+        That the bookmark is the maximum value sent to the target for the replication key.
+        That a second sync respects the bookmark
+            All data of the second sync is >= the bookmark from the first sync
+            The number of records in the 2nd sync is less then the first (This assumes that
+                new data added to the stream is done at a rate slow enough that you haven't
+                doubled the amount of data from the start date to the first sync between
+                the first sync and second sync run in this test)
+        Verify that for full table stream, all data replicated in sync 1 is replicated again in sync 2.
+        PREREQUISITE
+        For EACH stream that is incrementally replicated there are multiple rows of data with
+            different values for the replication key
+        """
+
+        streams_to_test = self.expected_streams()
+
+        # For following streams(except targeting_tv_markets and targeting_tv_shows), we are not able to generate any records.
+        # targeting_tv_markets and targeting_tv_shows streams take more than 5 hour to complete the sync.
+        #  So, skipping those streams from test case.
+        streams_to_test = streams_to_test - {'cards_image_conversation', 'cards_video_conversation', 'cards_image_direct_message',
+                                            'cards_video_direct_message', 'accounts_daily_report', 'campaigns_daily_report', 'accounts',
+                                            'targeting_tv_markets', 'targeting_tv_shows'}
+        
+        # Endpoints are swapped for content_categories and iab_categories streams - https://jira.talendforge.org/browse/TDL-18374        
+        streams_to_test = streams_to_test - {'iab_categories', 'content_categories'}
+
+        # Invalid endpoint for targeting_events stream - https://jira.talendforge.org/browse/TDL-18463
+        streams_to_test = streams_to_test - {'targeting_events'}
+        
+        # Invalid bookmark for tweets stream - https://jira.talendforge.org/browse/TDL-18465
+        streams_to_test = streams_to_test - {'tweets'}
+        
+        # Make child streams independent of parent stream https://jira.talendforge.org/browse/TDL-18089 
+        streams_to_test = streams_to_test - {'bidding_rules'}
+
+        # Deprecated stream
+        streams_to_test = streams_to_test - {'targeting_criteria'}
+
+        expected_replication_keys = self.expected_replication_keys()
+        expected_replication_methods = self.expected_replication_method()
+
+        ##########################################################################
+        # First Sync
+        ##########################################################################
+        conn_id = connections.ensure_connection(self)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        catalog_entries = [catalog for catalog in found_catalogs
+                           if catalog.get('tap_stream_id') in streams_to_test]
+
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, catalog_entries)
+
+        # Run a first sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Update State Between Syncs
+        ##########################################################################
+
+        new_states = {'bookmarks': dict()}
+        simulated_states = self.calculated_states_by_stream(
+            first_sync_bookmarks)
+        for stream, new_state in simulated_states.items():
+            new_states['bookmarks'][stream] = new_state
+        menagerie.set_state(conn_id, new_states)
+
+        ##########################################################################
+        # Second Sync
+        ##########################################################################
+
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Test By Stream
+        ##########################################################################
+
+
+        for stream in streams_to_test:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_replication_method = expected_replication_methods[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+                first_sync_messages = [record.get('data') for record in
+                                       first_sync_records.get(
+                                           stream, {}).get('messages', [])
+                                       if record.get('action') == 'upsert']
+                second_sync_messages = [record.get('data') for record in
+                                        second_sync_records.get(
+                                            stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert']
+                first_bookmark_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream, {}).get(self.account_id)
+                second_bookmark_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream, {}).get(self.account_id)
+
+
+                if expected_replication_method == self.INCREMENTAL:
+
+                    # collect information specific to incremental streams from syncs 1 & 2
+                    first_bookmark_value_utc = self.convert_state_to_utc(
+                        first_bookmark_value)
+                    second_bookmark_value_utc = self.convert_state_to_utc(
+                        second_bookmark_value)
+
+
+                    simulated_bookmark_value = self.convert_state_to_utc(new_states['bookmarks'][stream][self.account_id])
+
+                    # Verify the first sync sets a bookmark of the expected form
+                    self.assertIsNotNone(first_bookmark_value)
+
+                    # Verify the second sync sets a bookmark of the expected form
+                    self.assertIsNotNone(second_bookmark_value)
+
+                    # Verify the second sync bookmark is Equal to the first sync bookmark
+                    # assumes no changes to data during test
+                    self.assertEqual(second_bookmark_value, first_bookmark_value)
+
+                    # `targeting_criteria` is child stream of line_items stream which is incremental.
+                    # We are writing a separate bookmark for the child stream in which we are storing
+                    # the bookmark based on the parent's replication key.
+                    # But, we are not using any fields from the child record for it.
+                    if stream == "targeting_criteria":
+                        # collect parent pk value for 1st sync
+                        first_sync_child_foreign_keys = set()
+                        for record in first_sync_messages:
+                            first_sync_child_foreign_keys.add(record['line_item_id'])
+
+                        # collect parent pk value for 2nd sync
+                        second_sync_child_foreign_keys = set()
+                        for record in second_sync_messages:
+                            second_sync_child_foreign_keys.add(record['line_item_id'])
+
+                        # Verify that all foreign keys in the 2nd sync are available in in 1st sync also. 
+                        self.assertTrue(second_sync_child_foreign_keys.issubset(first_sync_child_foreign_keys))
+                    
+                    else:
+                        replication_key = next(iter(expected_replication_keys[stream]))
+
+                        for record in first_sync_messages:
+
+                            # Verify the first sync bookmark value is the max replication key value for a given stream
+                            replication_key_value = self.convert_state_to_utc(record.get(replication_key))
+
+                            self.assertLessEqual(
+                                replication_key_value, first_bookmark_value_utc,
+                                msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                            )
+
+                        for record in second_sync_messages:
+                            # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
+                            replication_key_value = self.convert_state_to_utc(record.get(replication_key))
+
+                            self.assertGreaterEqual(replication_key_value, simulated_bookmark_value,
+                                                    msg="Second sync records do not repect the previous bookmark.")
+
+                            # Verify the second sync bookmark value is the max replication key value for a given stream
+                            self.assertLessEqual(
+                                replication_key_value, second_bookmark_value_utc,
+                                msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                            )
+
+                elif expected_replication_method == self.FULL_TABLE:
+
+                    # Verify the syncs do not set a bookmark for full table streams
+                    self.assertIsNone(first_bookmark_value)
+                    self.assertIsNone(second_bookmark_value)
+
+                    # Verify the number of records in the second sync is the same as the first
+                    self.assertEqual(second_sync_count, first_sync_count)
+
+                else:
+                    raise NotImplementedError(
+                        "INVALID EXPECTATIONS\t\tSTREAM: {} REPLICATION_METHOD: {}".format(
+                            stream, expected_replication_method)
+                    )
+
+                # Verify at least 1 record was replicated in the second sync
+                self.assertGreater(
+                    second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))

--- a/tests/unittests/test_bookmark.py
+++ b/tests/unittests/test_bookmark.py
@@ -1,0 +1,46 @@
+import unittest
+from tap_twitter_ads.streams import TwitterAds
+
+class TestBookmark(unittest.TestCase):
+    """
+    Test the get_bookmark method for different values
+    """
+    stream = "dummy_stream"
+    default = "2018-01-28T00:00:00Z"
+    account_id = "account_1"
+    twitter_ads_object = TwitterAds()
+    
+    def test_empty_bookmark(self):
+        """ Test that if an empty state passed in get_bookmark then it returns the default value"""
+        state = {}
+        
+        bookmark = self.twitter_ads_object.get_bookmark(state, self.stream, self.default, self.account_id)
+        
+        self.assertEqual(bookmark, self.default)
+
+    def test_invalid_bookmark(self):
+        """ Test that if the `bookmarks` key does not found in the state then it returns the default value """
+
+        state = {'bookmark_1': {}}
+        
+        bookmark = self.twitter_ads_object.get_bookmark(state, self.stream, self.default, self.account_id)
+        
+        self.assertEqual(bookmark, self.default)
+
+    def test_account_1_valid_bookmark(self):
+        """ Test that if the valid bookmark is available in the state then it returns the bookmark value """
+
+        state = {'bookmarks': {self.stream: {self.account_id: "2017-01-28T00:00:00Z"}}}
+        
+        bookmark = self.twitter_ads_object.get_bookmark(state, self.stream, self.default, self.account_id)
+        
+        self.assertEqual(bookmark, "2017-01-28T00:00:00Z")
+
+    def test_account_1_null_bookmark(self):
+        """ Test that if the bookmark value is None in the state then it returns None"""
+
+        state = {'bookmarks': {self.stream: {self.account_id: None}}}
+        
+        bookmark = self.twitter_ads_object.get_bookmark(state, self.stream, self.default, self.account_id)
+        
+        self.assertEqual(bookmark, None)


### PR DESCRIPTION
# Description of change
- Updated `get_bookmark` and `write_bookmark` to retrieve and update bookmark value account wise.
- Added unit test cases and integration cases.

# Manual QA steps
 - Run the sync mode without state file and verify that tap write account wise bookmark.
 - Run the sync mode with state and verify that each stream respect bookmark account-wise.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
