### PR TITLE
TDL-19447 Update params for content_categories and iab_categories

### DIFF
--- a/tap_twitter_ads/streams.py
+++ b/tap_twitter_ads/streams.py
@@ -1241,10 +1241,7 @@ class ContentCategories(TwitterAds):
     data_key = 'data'
     key_properties = ['id']
     replication_method = 'FULL_TABLE'
-    params = {
-        'count': 1000,
-        'cursor': None
-    }
+    params = {}
 
 # Reference: https://developer.twitter.com/en/docs/ads/campaign-management/api-reference/funding-instruments#funding-instruments
 class FundingInstruments(TwitterAds):
@@ -1268,7 +1265,10 @@ class IabCategories(TwitterAds):
     data_key = 'data'
     key_properties = ['id']
     replication_method = 'FULL_TABLE'
-    params = {}
+    params = {
+        'count': 1000,
+        'cursor': None
+    }
 
 # Reference: https://developer.twitter.com/en/docs/ads/campaign-management/api-reference/targeting-criteria#targeting-criteria
 class TargetingCriteria(TwitterAds):

--- a/tests/test_twitter_ads_pagination.py
+++ b/tests/test_twitter_ads_pagination.py
@@ -26,18 +26,19 @@ class PaginationTest(TwitterAds):
                                            'targeting_devices', 'funding_instruments', 'promotable_users', 'accounts', 'tailored_audiences',
                                            'targeting_tv_markets', 'targeting_tv_shows'}
 
+        # Skipping `content_catagories` as It does not follow pagination.
+        expected_streams = expected_streams - {'content_categories'}
+
         # Reduce page_size to 2 due to less data.
         self.run_test(expected_streams=expected_streams - {"targeting_locations", "targeting_conversations"}, page_size=2)    
         
-        # Againg set page_size to 1000 for following streams because these streams containg more than 40000 records.
+        # Set page_size to 1000 for following streams because these streams contain more than 40000 records.
         # So, page_size of 2 get lot of time to get all records.
         self.run_test(expected_streams={"targeting_locations", "targeting_conversations"}, page_size=1000)
     
     def run_test(self, expected_streams, page_size):
 
         streams_to_test = expected_streams
-        # Endpoints are swapped for content_categories and iab_categories streams - https://jira.talendforge.org/browse/TDL-18374        
-        streams_to_test = streams_to_test - {'iab_categories', 'content_categories'}
 
         # Invalid endpoint for targeting_events stream - https://jira.talendforge.org/browse/TDL-18463
         streams_to_test = streams_to_test - {'targeting_events'}


### PR DESCRIPTION
# Description of change
- Added `count` and `cursor` parameters in the `iab_categories` stream.
-  Removed parameter from the `content_categories` stream.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
