### PR TITLE
use sub_type state value when updating state

### DIFF
--- a/tap_twitter_ads/streams.py
+++ b/tap_twitter_ads/streams.py
@@ -152,15 +152,14 @@ class TwitterAds:
             # Retrieve existing bookmark value if it is available in the state or assign empty dict.
             # Because we need to write bookmark value for each sub type inside the account_id. 
             state['bookmarks'][stream][account_id] = state['bookmarks'].get(stream, {}).get(account_id, {})
-            state['bookmarks'][stream][account_id][sub_type] = value[sub_type]
+            state['bookmarks'][stream][account_id][sub_type] = value
             LOGGER.info('Stream: {} Subtype: {} - Write state, bookmark value: {}'.format(stream, sub_type, value))
 
         else:
             state['bookmarks'][stream][account_id] = value # Update bookmark value for particular account
             LOGGER.info('Stream: {} - Write state, bookmark value: {}'.format(stream, value))
-        
         singer.write_state(state)
-            
+
     # Converts cursor object to dictionary
     def obj_to_dict(self, obj):
         if not hasattr(obj, "__dict__"):
@@ -329,7 +328,8 @@ class TwitterAds:
 
             if stream_name == "tweets" and last_datetime != start_date:
                 # Tweets stream contains two separate bookmarks for each sub_type(PUBLISHED, SCHEDULED)
-                last_dttm = strptime_to_utc(last_datetime.get(sub_type, start_date))
+                max_bookmark_value = last_datetime.get(sub_type, start_date)
+                last_dttm = strptime_to_utc(max_bookmark_value)
             else:
                 last_dttm = strptime_to_utc(last_datetime)
 


### PR DESCRIPTION
# Description of change
The `tweets` bookmark has two `sub_type`s (`PUBLISHED`, `SCHEDULED`). When updating bookmarks, `value` is a dict with both `sub_type`s when there are no records retrieved from the tweets endpoint.
```json
{"PUBLISHED": "2022-04-03T00:00:00Z", "SCHEDULED": "2022-04-03T00:00:00Z"}
```
State for each `sub_type` was being updated to the above dict instead of using each `sub_type`s value.

`max_bookmark_value` dictates what is sent to the `write_bookmarks` function. `max_bookmark_value` was only updated when records were returned from the tweets endpoint. This fix updates `max_bookmark_value` to be the correct value for each `sub_type` before iterating through the response.

# Manual QA steps
 - Verified runs successfully 
 
# Risks
 - Low. Each `sub_type` goes through the comparisons to update state.
 
# Rollback steps
 - revert this branch
