### PR TITLE
GL Work - Library version upgrades + support for `parent-tap-stream-id` metadata for child streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   * Added pagination parameter for `targeting devices` [#28](https://github.com/singer-io/tap-twitter-ads/pull/28)
   * Added missing tap-tester test cases [#20](https://github.com/singer-io/tap-twitter-ads/pull/20)
   * Resolved ConnectionResetError [#32](https://github.com/singer-io/tap-twitter-ads/pull/32)
-
+  
 ## 0.0.7
   * Update twitter-ads SDK to v9.0.1 [#13](https://github.com/singer-io/tap-twitter-ads/pull/13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.1.0
-  * Library version upgrades and Updated metadata for streams [#46](https://github.com/singer-io/tap-twitter-ads/pull/46)
+  * Library version upgrades and updated metadata for streams [#46](https://github.com/singer-io/tap-twitter-ads/pull/46)
 
 ## 1.0.0
   * Upgraded SDK and API version [#19](https://github.com/singer-io/tap-twitter-ads/pull/19)
@@ -18,7 +18,6 @@
   * Added pagination parameter for `targeting devices` [#28](https://github.com/singer-io/tap-twitter-ads/pull/28)
   * Added missing tap-tester test cases [#20](https://github.com/singer-io/tap-twitter-ads/pull/20)
   * Resolved ConnectionResetError [#32](https://github.com/singer-io/tap-twitter-ads/pull/32)
-  
 
 ## 0.0.7
   * Update twitter-ads SDK to v9.0.1 [#13](https://github.com/singer-io/tap-twitter-ads/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+  * Updated metadata for streams [#43](https://github.com/singer-io/tap-twitter-ads/pull/43)
+
+## 1.1.0
+  * Library version upgrades [#40](https://github.com/singer-io/tap-twitter-ads/pull/40)
+
 ## 1.0.0
   * Upgraded SDK and API version [#19](https://github.com/singer-io/tap-twitter-ads/pull/19)
   * Added credentials check in discover mode [#15](https://github.com/singer-io/tap-twitter-ads/pull/15)
@@ -16,6 +22,7 @@
   * Added missing tap-tester test cases [#20](https://github.com/singer-io/tap-twitter-ads/pull/20)
   * Resolved ConnectionResetError [#32](https://github.com/singer-io/tap-twitter-ads/pull/32)
   
+
 ## 0.0.7
   * Update twitter-ads SDK to v9.0.1 [#13](https://github.com/singer-io/tap-twitter-ads/pull/13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 # Changelog
 
-## 1.2.0
-  * Updated metadata for streams [#43](https://github.com/singer-io/tap-twitter-ads/pull/43)
-
 ## 1.1.0
-  * Library version upgrades [#40](https://github.com/singer-io/tap-twitter-ads/pull/40)
+  * Library version upgrades and Updated metadata for streams [#46](https://github.com/singer-io/tap-twitter-ads/pull/46)
 
 ## 1.0.0
   * Upgraded SDK and API version [#19](https://github.com/singer-io/tap-twitter-ads/pull/19)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-twitter-ads',
       install_requires=[
           'backoff==2.2.1',
           'requests==2.32.5',
-          'singer-python==6.1.1',
+          'singer-python==6.3.0',
           'twitter-ads==11.0.0'
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-twitter-ads',
-      version='1.2.0',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Twitter Ads API API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-twitter-ads',
-      version='1.0.0',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Twitter Ads API API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_twitter_ads'],
       install_requires=[
-          'backoff==1.8.0',
-          'requests==2.23.0',
-          'singer-python==5.9.0',
+          'backoff==2.2.1',
+          'requests==2.32.5',
+          'singer-python==6.1.1',
           'twitter-ads==11.0.0'
       ],
       extras_require={

--- a/tap_twitter_ads/schema.py
+++ b/tap_twitter_ads/schema.py
@@ -111,6 +111,14 @@ def get_schemas(reports):
             valid_replication_keys=(hasattr(stream_metadata, 'replication_keys') or None) and stream_metadata.replication_keys,
             replication_method=(hasattr(stream_metadata, 'replication_method') or None) and stream_metadata.replication_method
         )
+        mdata = metadata.to_map(mdata)
+
+        parent_tap_stream_id = getattr(stream_metadata, "parent_stream", None)
+        if parent_tap_stream_id:
+            mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
+
+        mdata = metadata.to_list(mdata)
+
         # Make replication keys of automatic inclusion
         mdata = make_replication_key_automatic(mdata, schema, (hasattr(stream_metadata, 'replication_keys') or None) and stream_metadata.replication_keys)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -138,7 +138,8 @@ class TwitterAds(unittest.TestCase):
                 # That's why the `targeting_criteria` stream does not have replication_key but still it is incremental.
                 self.PRIMARY_KEYS: {"line_item_id", "id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                "parent_stream": "line_items"
             },
             "media_creatives": default_metadata,
             "preroll_call_to_actions": default_metadata,
@@ -166,7 +167,12 @@ class TwitterAds(unittest.TestCase):
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.OBEYS_START_DATE: False
             },
-            "targeting_tv_shows": targeting_endpoint_metadata,
+            "targeting_tv_shows": {
+                self.PRIMARY_KEYS: {"targeting_value"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False,
+                "parent_stream": "targeting_tv_markets"
+            },
             "tweets": {
                 self.REPLICATION_KEYS: {"created_at"},
                 self.PRIMARY_KEYS: {"id"},
@@ -205,6 +211,12 @@ class TwitterAds(unittest.TestCase):
         return {table: properties.get(self.REPLICATION_METHOD, None)
                 for table, properties
                 in self.expected_metadata().items()}
+
+    def expected_parent_streams(self):
+        """return a dictionary with the key of child stream name and value as the parent stream name"""
+        return {stream: metadata.get('parent_stream') 
+            for stream, metadata in self.expected_metadata().items() 
+            if metadata.get('parent_stream')}
 
 #########################
 #   Helper Methods      #

--- a/tests/test_twitter_ads_discover.py
+++ b/tests/test_twitter_ads_discover.py
@@ -55,6 +55,7 @@ class DiscoverTest(TwitterAds):
                 expected_replication_keys = self.expected_replication_keys()[stream]
                 expected_automatic_fields = self.expected_automatic_fields()[stream]
                 expected_replication_method = self.expected_replication_method()[stream]
+                expected_parent_stream = self.expected_parent_streams().get(stream)
 
                 # collecting actual values...
                 schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
@@ -74,6 +75,7 @@ class DiscoverTest(TwitterAds):
                     item.get("breadcrumb", ["properties", None])[1] for item in metadata
                     if item.get("metadata").get("inclusion") == "automatic"
                 )
+                actual_parent_stream = stream_properties[0].get("metadata", {}).get("parent-tap-stream-id")
 
                 actual_fields = []
                 for md_entry in metadata:
@@ -117,6 +119,11 @@ class DiscoverTest(TwitterAds):
                     self.assertEqual(self.INCREMENTAL, actual_replication_method)
                 else:
                     self.assertEqual(self.FULL_TABLE, actual_replication_method)
+
+                # verify parent-tap-stream-id is correctly set for child streams
+                self.assertEqual(expected_parent_stream, actual_parent_stream,
+                                msg="expected parent stream {} but actual is {}".format(
+                                    expected_parent_stream, actual_parent_stream))
 
                 # verify that primary keys and replication keys
                 # are given the inclusion of automatic in metadata.

--- a/tests/test_twitter_ads_start_date.py
+++ b/tests/test_twitter_ads_start_date.py
@@ -46,7 +46,7 @@ class StartDateTest(TwitterAds):
         # For, some of the streams the maximum allowed page_size is 200. For, the greater value of page_size SDK throws the error.
         # So, revert back page_size to 200 for the rest of the streams.
         streams_to_test = streams_to_test - expected_stream_1 - expected_stream_2 - expected_stream_3
-        self.run_start_date(streams_to_test, new_start_date="2022-04-06T00:00:00Z")
+        self.run_start_date(streams_to_test, new_start_date="2025-09-15T00:00:00Z")
 
     def run_start_date(self, streams_to_test, new_start_date, page_size = 200):
         """

--- a/tests/unittests/test_metadata.py
+++ b/tests/unittests/test_metadata.py
@@ -1,0 +1,127 @@
+import unittest
+from unittest import mock
+from tap_twitter_ads.schema import get_schemas
+from tap_twitter_ads import streams
+from singer import metadata
+
+
+class TestParentTapStreamIdMetadata(unittest.TestCase):
+    """Unit tests for parent-tap-stream-id metadata functionality."""
+
+    def test_parent_tap_stream_id_added_to_child_streams(self):
+        """Test that parent-tap-stream-id is added to metadata for child streams."""
+        from tap_twitter_ads.streams import STREAMS
+        
+        # Mock reports (empty since we're testing stream metadata)
+        reports = []
+
+        # Get schemas and metadata
+        schemas, field_metadata = get_schemas(reports)
+        
+        # Dynamically find all child streams (streams with parent_stream attribute)
+        expected_child_streams = {}
+        for stream_name, stream_class in STREAMS.items():
+            if hasattr(stream_class, 'parent_stream'):
+                expected_child_streams[stream_name] = stream_class.parent_stream
+        
+        # Test each child stream dynamically
+        for child_stream, expected_parent in expected_child_streams.items():
+            with self.subTest(child_stream=child_stream, expected_parent=expected_parent):
+                # Verify child stream exists in metadata
+                self.assertIn(child_stream, field_metadata, 
+                             f"Child stream '{child_stream}' not found in field metadata")
+                
+                child_metadata = field_metadata[child_stream]
+                
+                # Convert to map for easier access
+                mdata_map = metadata.to_map(child_metadata)
+                
+                # Verify parent-tap-stream-id is set correctly
+                actual_parent_stream_id = metadata.get(mdata_map, (), 'parent-tap-stream-id')
+                self.assertEqual(actual_parent_stream_id, expected_parent,
+                               f"Child stream '{child_stream}' should have parent-tap-stream-id '{expected_parent}' "
+                               f"but got '{actual_parent_stream_id}'")
+
+    def test_parent_tap_stream_id_not_added_to_parent_streams(self):
+        """Test that parent-tap-stream-id is not added to parent streams."""
+        from tap_twitter_ads.streams import STREAMS
+        
+        # Mock reports (empty since we're testing stream metadata)
+        reports = []
+        
+        # Get schemas and metadata
+        schemas, field_metadata = get_schemas(reports)
+        
+        # Dynamically find all parent streams (streams that are referenced as parents)
+        child_streams = {}
+        for stream_name, stream_class in STREAMS.items():
+            if hasattr(stream_class, 'parent_stream'):
+                child_streams[stream_name] = stream_class.parent_stream
+        
+        parent_streams = set(child_streams.values())
+        
+        # Test each parent stream dynamically
+        for parent_stream in parent_streams:
+            with self.subTest(parent_stream=parent_stream):
+                # Verify parent stream exists in metadata
+                self.assertIn(parent_stream, field_metadata,
+                             f"Parent stream '{parent_stream}' not found in field metadata")
+                
+                parent_metadata = field_metadata[parent_stream]
+                
+                # Convert to map for easier access
+                mdata_map = metadata.to_map(parent_metadata)
+                
+                # Verify parent-tap-stream-id is not set for parent streams
+                parent_stream_id = metadata.get(mdata_map, (), 'parent-tap-stream-id')
+                self.assertIsNone(parent_stream_id,
+                                 f"Parent stream '{parent_stream}' should not have parent-tap-stream-id "
+                                 f"but got '{parent_stream_id}'")
+
+    def test_stream_classes_have_correct_parent_stream_attribute(self):
+        """Test that child stream classes have the correct parent_stream attribute."""
+        from tap_twitter_ads.streams import STREAMS
+        
+        # Dynamically test all stream classes
+        child_streams = {}
+        parent_streams = set()
+        regular_streams = set()
+        
+        for stream_name, stream_class in STREAMS.items():
+            if hasattr(stream_class, 'parent_stream'):
+                child_streams[stream_name] = stream_class.parent_stream
+                parent_streams.add(stream_class.parent_stream)
+            else:
+                regular_streams.add(stream_name)
+        
+        # Test child stream classes have parent_stream attribute
+        for stream_name, expected_parent in child_streams.items():
+            with self.subTest(stream_name=stream_name, stream_type="child"):
+                stream_class = STREAMS[stream_name]
+                stream_instance = stream_class()
+                
+                self.assertTrue(hasattr(stream_instance, 'parent_stream'),
+                              f"Child stream class '{stream_name}' should have parent_stream attribute")
+                self.assertEqual(stream_instance.parent_stream, expected_parent,
+                               f"Child stream '{stream_name}' should have parent_stream '{expected_parent}' "
+                               f"but got '{stream_instance.parent_stream}'")
+        
+        # Test that parent streams don't have parent_stream attribute
+        for stream_name in parent_streams:
+            if stream_name in STREAMS:  # Only test if the parent stream is in STREAMS
+                with self.subTest(stream_name=stream_name, stream_type="parent"):
+                    stream_class = STREAMS[stream_name]
+                    stream_instance = stream_class()
+                    
+                    self.assertFalse(hasattr(stream_instance, 'parent_stream'),
+                                   f"Parent stream class '{stream_name}' should not have parent_stream attribute")
+        
+        # Test that regular (non-child, non-parent) streams don't have parent_stream attribute
+        regular_non_parent_streams = regular_streams - parent_streams
+        for stream_name in list(regular_non_parent_streams)[:3]:  # Test a few regular streams to avoid too many subtests
+            with self.subTest(stream_name=stream_name, stream_type="regular"):
+                stream_class = STREAMS[stream_name]
+                stream_instance = stream_class()
+                
+                self.assertFalse(hasattr(stream_instance, 'parent_stream'),
+                               f"Regular stream class '{stream_name}' should not have parent_stream attribute")

--- a/tests/unittests/test_metadata.py
+++ b/tests/unittests/test_metadata.py
@@ -118,7 +118,7 @@ class TestParentTapStreamIdMetadata(unittest.TestCase):
         
         # Test that regular (non-child, non-parent) streams don't have parent_stream attribute
         regular_non_parent_streams = regular_streams - parent_streams
-        for stream_name in list(regular_non_parent_streams)[:3]:  # Test a few regular streams to avoid too many subtests
+        for stream_name in regular_non_parent_streams:
             with self.subTest(stream_name=stream_name, stream_type="regular"):
                 stream_class = STREAMS[stream_name]
                 stream_instance = stream_class()


### PR DESCRIPTION

**Description:**
This PR introduces support for `parent-tap-stream-id` metadata in child streams during discovery and upgrades key dependencies (`backoff`, `requests`, `singer-python`). It also includes related test and documentation updates to ensure consistency and proper functionality.

---

**Linked Tickets & PRs:**

* **[[SAC-28600](https://qlik-dev.atlassian.net/browse/SAC-28600)](https://qlik-dev.atlassian.net/browse/SAC-28600)** – Dependency upgrades

  * [[PR #40](https://github.com/singer-io/tap-twitter-ads/pull/40)](https://github.com/singer-io/tap-twitter-ads/pull/40)
* **[[SAC-28896](https://qlik-dev.atlassian.net/browse/SAC-28896)](https://qlik-dev.atlassian.net/browse/SAC-28896)** – Metadata enhancement

  * [[PR #43](https://github.com/singer-io/tap-twitter-ads/pull/43)](https://github.com/singer-io/tap-twitter-ads/pull/43)
* **[[SAC-29404](https://qlik-dev.atlassian.net/browse/SAC-29404)](https://qlik-dev.atlassian.net/browse/SAC-29404)** – Start-date test updates

  * [[PR #45](https://github.com/singer-io/tap-twitter-ads/pull/45)](https://github.com/singer-io/tap-twitter-ads/pull/45)

---

**Changes Covered:**

* Added `parent-tap-stream-id` metadata for child streams
* Enhanced discovery logic and updated corresponding unit tests
* Upgraded dependencies (`backoff`, `requests`, `singer-python`)
* Updated `CHANGELOG.md` for version bump and feature addition

---

**Manual QA Steps:**

1. Ran discovery locally using:

   ```bash
   tap-twitter-ads --config config.json --discover
   ```

   → Verified `parent-tap-stream-id` in child stream metadata
2. Ran tests with:

   ```bash
   pytest tests/
   ```

   → All tests passed successfully

<img width="1419" height="347" alt="twitter-ads-catalog" src="https://github.com/user-attachments/assets/db53cb6c-7b75-4988-9e61-b0c5536f5ac0" />

 
---

**Rollback steps:**
 - revert this branch

